### PR TITLE
Fix sellWithContribution values

### DIFF
--- a/contracts/reserve/GoodMarketMaker.sol
+++ b/contracts/reserve/GoodMarketMaker.sol
@@ -366,12 +366,12 @@ contract GoodMarketMaker is Initializable, DSMath, OwnableUpgradeable {
 
 		// The return value after the deduction
 		uint256 tokenReturn = sellReturn(_token, amountAfterContribution);
-		rtoken.gdSupply = rtoken.gdSupply.sub(_gdAmount);
+		rtoken.gdSupply = rtoken.gdSupply.sub(amountAfterContribution);
 		rtoken.reserveSupply = rtoken.reserveSupply.sub(tokenReturn);
 		emit BalancesUpdated(
 			msg.sender,
 			address(_token),
-			_contributionGdAmount,
+			amountAfterContribution,
 			tokenReturn,
 			rtoken.gdSupply,
 			rtoken.reserveSupply


### PR DESCRIPTION
I think this section needs to be checked.

https://github.com/GoodDollar/GoodProtocol/blob/3a31e738b8ee9b4511b76d1f50543c072303f55e/contracts/reserve/GoodMarketMaker.sol#L364-L378

The `sell` function emits `BalancesUpdated` with `_gdAmount` which corresponds to the sold amount on
https://github.com/GoodDollar/GoodProtocol/blob/3a31e738b8ee9b4511b76d1f50543c072303f55e/contracts/reserve/GoodMarketMaker.sol#L327

So, `sellWithContribution` function should use `amountAfterContribution` value on `BalancesUpdated`.

Also, since `amountAfterContribution` is the sold amount on
https://github.com/GoodDollar/GoodProtocol/blob/3a31e738b8ee9b4511b76d1f50543c072303f55e/contracts/reserve/GoodMarketMaker.sol#L368

`amountAfterContribution` should be the value subtracted when updating `rtoken.gdSupply`.