### PR TITLE
feat: add adminBurn function to allow owner to destroy illegitimate t…

### DIFF
--- a/contracts/token/superfluid/ISuperGoodDollar.sol
+++ b/contracts/token/superfluid/ISuperGoodDollar.sol
@@ -55,6 +55,8 @@ interface IGoodDollarCustom {
 
 	function burnFrom(address account, uint256 amount) external;
 
+	function adminBurn(address account, uint256 amount) external;
+
 	function addMinter(address _minter) external;
 
 	function renounceMinter() external;

--- a/contracts/token/superfluid/SuperGoodDollar.sol
+++ b/contracts/token/superfluid/SuperGoodDollar.sol
@@ -308,6 +308,20 @@ contract SuperGoodDollar is
 	}
 
 	/**
+	 * @dev Admin burn, to destroy illegitimate G$ (eg. obtained through an exploit).
+	 * Owner only. Works while paused, needs no allowance, charges no fees, and bypasses the
+	 * ERC777 `tokensToSend` hook so a holder can not block the burn with a reverting
+	 * ERC1820 implementer. Reverts if `amount` exceeds the available (realtime) balance.
+	 */
+	function adminBurn(address account, uint256 amount) external override {
+		_onlyOwner();
+		// low level burn: no ERC777 hooks, no pause check, no fees
+		SuperfluidToken._burn(account, amount);
+		emit Burned(msg.sender, account, amount, new bytes(0), new bytes(0));
+		emit IERC20.Transfer(account, address(0), amount);
+	}
+
+	/**
 	 * @dev Gets the current transaction fees
 	 * @return fee senderPays  that represents the current transaction fees and bool true if sender pays the fee or receiver
 	 */
@@ -383,13 +397,6 @@ contract SuperGoodDollar is
 	) internal {
 		poolAdminNFT = _poolAdminNFT;
 		poolMemberNFT = _poolMemberNFT;
-	}
-
-	function recover(IERC20 token) public {
-		token.transfer(
-			getRoleMember(DEFAULT_ADMIN_ROLE, 0),
-			token.balanceOf(address(this))
-		);
 	}
 
 	/**************************************************************************

--- a/test/token/SuperGoodDollar.test.ts
+++ b/test/token/SuperGoodDollar.test.ts
@@ -178,6 +178,51 @@ describe("SuperGoodDollar", async function () {
     await sgd.transfer(bob.address, tenDollars);
   });
 
+  it("adminBurn destroys illegitimate funds and reduces total supply", async function () {
+    await loadFixture(initialState);
+    await sgd.mint(eve.address, tenDollars);
+    const supplyBefore = await sgd.totalSupply();
+
+    await expect(sgd.connect(founder).adminBurn(eve.address, tenDollars))
+      .emit(sgd, "Burned")
+      .withArgs(founder.address, eve.address, tenDollars, "0x", "0x");
+
+    expect(await sgd.balanceOf(eve.address)).equal(0);
+    expect(await sgd.totalSupply()).equal(supplyBefore.sub(tenDollars));
+  });
+
+  it("adminBurn is only callable by the owner", async function () {
+    await loadFixture(initialState);
+    await sgd.mint(eve.address, tenDollars);
+
+    await expect(
+      sgd.connect(eve).adminBurn(eve.address, tenDollars)
+    ).revertedWith("not owner");
+    await expect(
+      sgd.connect(alice).adminBurn(eve.address, tenDollars)
+    ).revertedWith("not owner");
+  });
+
+  it("adminBurn works while paused", async function () {
+    await loadFixture(initialState);
+    await sgd.mint(eve.address, tenDollars);
+    await sgd.connect(founder).pause();
+
+    await sgd.connect(founder).adminBurn(eve.address, tenDollars);
+    expect(await sgd.balanceOf(eve.address)).equal(0);
+
+    await sgd.connect(founder).unpause();
+  });
+
+  it("adminBurn reverts when exceeding the available balance", async function () {
+    await loadFixture(initialState);
+    await sgd.mint(eve.address, tenDollars);
+
+    await expect(
+      sgd.connect(founder).adminBurn(eve.address, tenDollars.mul(2))
+    ).reverted;
+  });
+
   it("non-zero fees are applied", async function () {
     await loadFixture(initialState);
 


### PR DESCRIPTION
# Description

Adds adminBurn(address account, uint256 amount) to SuperGoodDollar so the DAO can destroy illegitimate G$ (e.g. tokens obtained through an exploit).

Removes recover(IERC20) to stay under the EIP-170 contract size limit.
## Why not reuse `_burn`?

`burn` / `burnFrom` go through `SuperGoodDollar._burn`, which is unusable for a clawback:

| | `_burn` (override) | `SuperToken._burn` | `SuperfluidToken._burn` (used) |
|---|---|---|---|
| reverts while paused | ✅ yes | no | no |
| runs holder's ERC777 `tokensToSend` hook | ✅ yes | ✅ yes | no |

1. **Pause.** `SuperGoodDollar._burn` calls `_onlyNotPaused()`. Pausing is the first move in an incident and burning the illegitimate supply is the next, so the function would revert exactly when it is needed.
2. **ERC777 hook.** `SuperToken._burn` calls `_callTokensToSend`, which invokes a contract the *holder* registered in the ERC1820 registry. A holder can register an implementer that always reverts and make themselves permanently un-burnable. The hook also fires before balances are updated, so it is a reentrancy surface — and `adminBurn` runs while paused, when other guards are off.

`adminBurn` therefore drops to `SuperfluidToken._burn` and emits `Burned` / `Transfer` itself. The available-balance check in `SuperfluidToken._burn` still applies, so a burn can never eat into the deposit backing an active Superfluid stream.

Access is `_onlyOwner()` (`DEFAULT_ADMIN_ROLE`). No new role was introduced — clawback is the most dangerous power on the token and should not be delegable by default.

About # (link your issue here)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

# Checklist:
- [ ] PR title matches follow: (Feature|Bug|Chore) Task Name
- [ ] My code follows the style guidelines of this project
- [ ] I have followed all the instructions described in the initial task (check Definitions of Done)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added reference to a related issue in the repository
- [ ] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [ ] @mentions of the person or team responsible for reviewing proposed changes

## Summary by Sourcery

Enable the token owner to safely claw back illegitimate G$ while preserving Superfluid balance constraints.

New Features:
- Add an owner-only admin burn capability for destroying illegitimate token balances, including while the token is paused.

Enhancements:
- Remove the token recovery function to remain within the contract size limit.

Tests:
- Add coverage for successful administrative burns, owner authorization, paused-state operation, and insufficient available balance reverts.