### PR TITLE
feat: AdminBurnExecutor — auditable one-shot scheme for burning illegitimate G$

### DIFF
--- a/contracts/token/superfluid/ISuperGoodDollar.sol
+++ b/contracts/token/superfluid/ISuperGoodDollar.sol
@@ -55,6 +55,8 @@ interface IGoodDollarCustom {
 
 	function burnFrom(address account, uint256 amount) external;
 
+	function adminBurn(address account, uint256 amount) external;
+
 	function addMinter(address _minter) external;
 
 	function renounceMinter() external;

--- a/contracts/token/superfluid/SuperGoodDollar.sol
+++ b/contracts/token/superfluid/SuperGoodDollar.sol
@@ -308,6 +308,20 @@ contract SuperGoodDollar is
 	}
 
 	/**
+	 * @dev Admin burn, to destroy illegitimate G$ (eg. obtained through an exploit).
+	 * Owner only. Works while paused, needs no allowance, charges no fees, and bypasses the
+	 * ERC777 `tokensToSend` hook so a holder can not block the burn with a reverting
+	 * ERC1820 implementer. Reverts if `amount` exceeds the available (realtime) balance.
+	 */
+	function adminBurn(address account, uint256 amount) external override {
+		_onlyOwner();
+		// low level burn: no ERC777 hooks, no pause check, no fees
+		SuperfluidToken._burn(account, amount);
+		emit Burned(msg.sender, account, amount, new bytes(0), new bytes(0));
+		emit IERC20.Transfer(account, address(0), amount);
+	}
+
+	/**
 	 * @dev Gets the current transaction fees
 	 * @return fee senderPays  that represents the current transaction fees and bool true if sender pays the fee or receiver
 	 */
@@ -383,13 +397,6 @@ contract SuperGoodDollar is
 	) internal {
 		poolAdminNFT = _poolAdminNFT;
 		poolMemberNFT = _poolMemberNFT;
-	}
-
-	function recover(IERC20 token) public {
-		token.transfer(
-			getRoleMember(DEFAULT_ADMIN_ROLE, 0),
-			token.balanceOf(address(this))
-		);
 	}
 
 	/**************************************************************************

--- a/contracts/utils/AdminBurnExecutor.sol
+++ b/contracts/utils/AdminBurnExecutor.sol
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+import "../DAOStackInterfaces.sol";
+
+interface IAdminBurnable {
+	function adminBurn(address account, uint256 amount) external;
+
+	function owner() external view returns (address);
+
+	function balanceOf(address account) external view returns (uint256);
+}
+
+/**
+ * @notice One-shot scheme that burns illegitimate G$ from a fixed list of
+ * addresses and records the USD refund owed to each of them.
+ *
+ * The list is fixed at construction time, so guardians can audit the exact
+ * (account, G$ amount, USD refund) tuples before registering this contract as a
+ * scheme with genericCall permission on the Controller. The contract has no way
+ * to burn anything that is not in the list, and no way to change the list.
+ *
+ * Flow:
+ *  1. deploy with the full list
+ *  2. guardians register this address as a scheme (genericCall permission)
+ *  3. anyone (or `owner`, see `execute`) calls `execute()`
+ *  4. the contract unregisters itself, permanently disarming it
+ *
+ * The USD refund amounts are *recorded only* - they are emitted per account and
+ * kept readable on-chain for the off-chain compensation process. This contract
+ * does not move USD or any stablecoin.
+ */
+contract AdminBurnExecutor {
+	struct BurnEntry {
+		address account;
+		uint256 gdAmount; // G$ to burn, 18 decimals (SuperGoodDollar)
+		uint256 refundUSD; // USD owed back to `account`, 18 decimals
+	}
+
+	event AdminBurn(address indexed account, uint256 gdAmount, uint256 refundUSD);
+	event Executed(
+		uint256 entries,
+		uint256 totalGDBurned,
+		uint256 totalRefundUSD
+	);
+
+	Controller public immutable controller;
+	IAdminBurnable public immutable token;
+	address public owner;
+
+	/// @notice sum of all `gdAmount` in the list, checked against the actual burns
+	uint256 public immutable totalGDToBurn;
+	/// @notice sum of all `refundUSD` in the list
+	uint256 public immutable totalRefundUSD;
+
+	BurnEntry[] public entries;
+
+	bool public executed;
+
+	constructor(
+		Controller _controller,
+		IAdminBurnable _token,
+		address _owner,
+		BurnEntry[] memory _entries
+	) {
+		require(address(_controller) != address(0), "controller required");
+		require(address(_token) != address(0), "token required");
+		require(_entries.length > 0, "empty burn list");
+
+		controller = _controller;
+		token = _token;
+		owner = _owner;
+
+		uint256 gd;
+		uint256 usd;
+		for (uint256 i = 0; i < _entries.length; i++) {
+			BurnEntry memory e = _entries[i];
+			require(e.account != address(0), "zero account");
+			require(e.gdAmount > 0, "zero burn amount");
+			// duplicates would make the pre-flight balance check misleading
+			for (uint256 j = 0; j < i; j++)
+				require(_entries[j].account != e.account, "duplicate account");
+
+			entries.push(e);
+			gd += e.gdAmount;
+			usd += e.refundUSD;
+		}
+		totalGDToBurn = gd;
+		totalRefundUSD = usd;
+	}
+
+	function entriesCount() external view returns (uint256) {
+		return entries.length;
+	}
+
+	function getEntries() external view returns (BurnEntry[] memory) {
+		return entries;
+	}
+
+	/**
+	 * @notice read-only pre-flight: are all listed balances still sufficient?
+	 * Guardians can call this before signing the scheme registration, and it is
+	 * re-checked inside `execute`.
+	 */
+	function canExecute()
+		external
+		view
+		returns (bool ok, address firstShortAccount)
+	{
+		address avatar = controller.avatar();
+		if (token.owner() != avatar) return (false, address(0));
+		if (!controller.isSchemeRegistered(address(this), avatar))
+			return (false, address(0));
+		for (uint256 i = 0; i < entries.length; i++)
+			if (token.balanceOf(entries[i].account) < entries[i].gdAmount)
+				return (false, entries[i].account);
+
+		return (!executed, address(0));
+	}
+
+	/**
+	 * @notice burn the whole list in one transaction, then unregister.
+	 * All or nothing: if a single burn fails, the whole transaction reverts and
+	 * the scheme stays armed so it can be retried.
+	 */
+	function execute() external {
+		require(msg.sender == owner, "not owner");
+		require(!executed, "already executed");
+		executed = true;
+
+		address avatar = controller.avatar();
+		// adminBurn is owner-only on the token, and the owner must be the Avatar
+		// for the genericCall to be accepted
+		require(token.owner() == avatar, "token owner is not the avatar");
+
+		uint256 burned;
+		uint256 len = entries.length;
+		for (uint256 i = 0; i < len; i++) {
+			BurnEntry memory e = entries[i];
+			uint256 balanceBefore = token.balanceOf(e.account);
+			require(balanceBefore >= e.gdAmount, "insufficient balance");
+
+			(bool ok, ) = controller.genericCall(
+				address(token),
+				abi.encodeCall(IAdminBurnable.adminBurn, (e.account, e.gdAmount)),
+				avatar,
+				0
+			);
+			require(ok, "adminBurn failed");
+			// genericCall swallows reverts of non-existent functions on some
+			// proxies, so verify the balance actually moved
+			require(
+				token.balanceOf(e.account) == balanceBefore - e.gdAmount,
+				"burn had no effect"
+			);
+
+			burned += e.gdAmount;
+			emit AdminBurn(e.account, e.gdAmount, e.refundUSD);
+		}
+
+		require(burned == totalGDToBurn, "burn total mismatch");
+		emit Executed(len, burned, totalRefundUSD);
+
+		owner = address(0); // mark as run
+		// prevent this contract from ever calling genericCall again
+		require(controller.unregisterSelf(avatar), "unregistering failed");
+	}
+
+	/**
+	 * @notice give up the permission without burning anything (abort path).
+	 */
+	function cancel() external {
+		require(msg.sender == owner, "not owner");
+		owner = address(0);
+		address avatar = controller.avatar();
+		if (controller.isSchemeRegistered(address(this), avatar))
+			require(controller.unregisterSelf(avatar), "unregistering failed");
+	}
+}

--- a/scripts/upgrades/admin-burn-executor-deploy.ts
+++ b/scripts/upgrades/admin-burn-executor-deploy.ts
@@ -1,0 +1,313 @@
+/***
+ * Deploy the AdminBurnExecutor and hand it to the guardians for approval.
+ *
+ * The burn list is fixed at construction time, so what the guardians register is
+ * exactly what they audited. Nothing here changes production state: the executor
+ * is inert until 5 of 9 guardians sign `registerScheme` in the Safe UI, and it can
+ * only burn after that.
+ *
+ * Requires the SuperGoodDollar implementation with `adminBurn` to already be live
+ * (see supergooddollar-admin-burn.ts).
+ *
+ * Burn list (BURN_LIST, default scripts/upgrades/admin-burn-list.json):
+ *   [{ "account": "0x..", "gd": "1234.56", "refundUSD": "78.90", "note": "optional" }]
+ *   `gd` is in whole G$ and `refundUSD` in whole USD - both are parsed to 18 decimals.
+ *   Raw base units can be given instead as `gdWei` / `refundUSDWei`.
+ *
+ * Modes (env):
+ *   DRY=true        validate the list + preflight balances, deploy nothing
+ *   DEPLOY_ONLY=1   deploy + verify, then stop (no Safe proposal)
+ *   EXECUTOR=0x..   skip deployment and propose registration for this address
+ *   PRINT_ONLY=1    print the raw Safe transaction instead of proposing it
+ *   STRICT_SIGNER=1 enforce the repo's canonical deployer address
+ */
+import fs from "fs";
+import path from "path";
+import { network, ethers } from "hardhat";
+import { execSync } from "child_process";
+import { executeViaSafe, executeViaGuardian, printDeploy, verifyProductionSigner } from "../multichain-deploy/helpers";
+import dao from "../../releases/deployment.json";
+
+let { name: networkName } = network;
+networkName = networkName.replace("-fork", "");
+
+const isSimulation = ["hardhat", "fork", "localhost"].includes(network.name);
+
+// executeViaSafe keys its chainId/RPC off these short names, not the hardhat name.
+const SAFE_NETWORK: { [k: string]: string } = {
+  "production-celo": "celo",
+  "production-xdc": "xdc",
+  "production-mainnet": "mainnet",
+  production: "fuse"
+};
+
+// Controller permission bits: 0x10 == genericCall, nothing else.
+const GENERIC_CALL_PERMISSION = "0x00000010";
+
+const DRY = process.env.DRY === "true" || process.env.DRY === "1";
+const DEPLOY_ONLY = process.env.DEPLOY_ONLY === "true" || process.env.DEPLOY_ONLY === "1";
+
+export type BurnListItem = {
+  account: string;
+  gd?: string | number;
+  gdWei?: string;
+  refundUSD?: string | number;
+  refundUSDWei?: string;
+  note?: string;
+};
+
+/**
+ * Parse + validate the burn list. Throws on anything the contract's constructor
+ * would reject, so a bad list fails before it costs a deployment.
+ */
+export const loadBurnList = (file: string) => {
+  const raw = JSON.parse(fs.readFileSync(file, "utf8")) as BurnListItem[];
+  if (!Array.isArray(raw) || raw.length === 0) throw new Error(`${file}: expected a non-empty array`);
+
+  const seen = new Set<string>();
+  return raw.map((item, i) => {
+    const where = `${file}[${i}]`;
+    let account: string;
+    try {
+      account = ethers.utils.getAddress(item.account);
+    } catch {
+      throw new Error(`${where}: invalid address '${item.account}'`);
+    }
+    if (seen.has(account.toLowerCase())) throw new Error(`${where}: duplicate account ${account}`);
+    seen.add(account.toLowerCase());
+
+    if (item.gd == null && item.gdWei == null) throw new Error(`${where}: missing 'gd' or 'gdWei'`);
+    const gdAmount = item.gdWei ? ethers.BigNumber.from(item.gdWei) : ethers.utils.parseEther(String(item.gd));
+    if (gdAmount.lte(0)) throw new Error(`${where}: burn amount must be > 0`);
+
+    const refundUSD = item.refundUSDWei
+      ? ethers.BigNumber.from(item.refundUSDWei)
+      : ethers.utils.parseEther(String(item.refundUSD ?? 0));
+
+    return { account, gdAmount, refundUSD, note: item.note ?? "" };
+  });
+};
+
+export const deploy = async () => {
+  const isProduction = networkName.includes("production");
+  const [root] = await ethers.getSigners();
+  const release: { [key: string]: any } = dao[networkName];
+
+  if (!release?.GoodDollar) throw new Error(`no GoodDollar in deployment.json for network '${networkName}'`);
+  const safeAddress = release.GuardiansSafe;
+  if (!safeAddress) throw new Error(`no GuardiansSafe in deployment.json for network '${networkName}'`);
+
+  if (isProduction && process.env.STRICT_SIGNER) verifyProductionSigner(root);
+
+  const listFile = path.resolve(process.env.BURN_LIST || path.join(__dirname, "admin-burn-list.json"));
+  const entries = loadBurnList(listFile);
+  const totalGD = entries.reduce((a, e) => a.add(e.gdAmount), ethers.constants.Zero);
+  const totalUSD = entries.reduce((a, e) => a.add(e.refundUSD), ethers.constants.Zero);
+
+  const supergd = await ethers.getContractAt("SuperGoodDollar", release.GoodDollar);
+  const owner = await supergd.owner();
+
+  console.log("=== target ===");
+  console.log({
+    networkName,
+    burnList: listFile,
+    token: release.GoodDollar,
+    tokenOwner: owner,
+    avatar: release.Avatar,
+    controller: release.Controller,
+    guardiansSafe: safeAddress,
+    deployer: root.address,
+    deployerBalance: (await ethers.provider.getBalance(root.address)).toString()
+  });
+
+  if (owner.toLowerCase() !== release.Avatar.toLowerCase())
+    throw new Error(`token owner ${owner} is not the Avatar ${release.Avatar} - adminBurn would revert`);
+
+  // the executor is useless against an implementation that has no adminBurn
+  if (!supergd.interface.functions["adminBurn(address,uint256)"])
+    throw new Error("local artifacts have no adminBurn(address,uint256) - run `yarn compile`");
+  // ...and against a *live* implementation that has no adminBurn either. The
+  // proxy would delegate the call into an implementation that reverts, so check
+  // the selector is actually present in the deployed code.
+  const selector = supergd.interface.getSighash("adminBurn(address,uint256)");
+  const liveImpl = await supergd.getCodeAddress();
+  const liveCode = await ethers.provider.getCode(liveImpl);
+  if (!liveCode.includes(selector.slice(2)))
+    throw new Error(
+      `live SuperGoodDollar implementation ${liveImpl} has no adminBurn - run supergooddollar-admin-burn.ts first`
+    );
+  console.log("live implementation:", liveImpl, "(adminBurn present)");
+
+  // ---------------------------------------------------------------- the list
+  console.log("\n=== burn list ===");
+  const rows: any[] = [];
+  let short = 0;
+  for (const e of entries) {
+    const balance = await supergd.balanceOf(e.account);
+    const enough = balance.gte(e.gdAmount);
+    if (!enough) short++;
+    rows.push({
+      account: e.account,
+      burnGD: ethers.utils.formatEther(e.gdAmount),
+      balanceGD: ethers.utils.formatEther(balance),
+      enough,
+      refundUSD: ethers.utils.formatEther(e.refundUSD),
+      note: e.note
+    });
+  }
+  console.table(rows);
+  console.log({
+    accounts: entries.length,
+    totalBurnGD: ethers.utils.formatEther(totalGD),
+    totalRefundUSD: ethers.utils.formatEther(totalUSD),
+    totalSupplyGD: ethers.utils.formatEther(await supergd.totalSupply()),
+    accountsWithInsufficientBalance: short
+  });
+  if (short > 0)
+    console.warn(
+      `WARNING: ${short} account(s) hold less than the listed amount. execute() is all-or-nothing and would revert.`
+    );
+
+  if (DRY) return console.log("\nDRY run complete - list validated, nothing deployed.");
+
+  // ---------------------------------------------------------------- deploy
+  let executorAddress = process.env.EXECUTOR;
+  if (executorAddress) {
+    console.log("\n=== using existing executor ===", executorAddress);
+    if ((await ethers.provider.getCode(executorAddress)).length <= 2)
+      throw new Error(`no code at EXECUTOR ${executorAddress}`);
+  } else {
+    console.log("\n=== deploying AdminBurnExecutor ===");
+    const ctorEntries = entries.map(e => [e.account, e.gdAmount, e.refundUSD]);
+    const executor = await ethers
+      .deployContract("AdminBurnExecutor", [release.Controller, release.GoodDollar, root.address, ctorEntries])
+      .then(printDeploy);
+    executorAddress = (executor as any).address;
+  }
+
+  const executor = await ethers.getContractAt("AdminBurnExecutor", executorAddress);
+
+  // ---------------------------------------------------------------- preflight
+  console.log("\n=== preflight ===");
+  const [onChainGD, onChainUSD, count] = await Promise.all([
+    executor.totalGDToBurn(),
+    executor.totalRefundUSD(),
+    executor.entriesCount()
+  ]);
+  console.log({
+    entries: count.toString(),
+    totalGDToBurn: ethers.utils.formatEther(onChainGD),
+    totalRefundUSD: ethers.utils.formatEther(onChainUSD),
+    owner: await executor.owner()
+  });
+  if (!onChainGD.eq(totalGD) || !onChainUSD.eq(totalUSD) || !count.eq(entries.length))
+    throw new Error("deployed executor does not match the local burn list");
+
+  // not registered yet, so canExecute is expected to be false on the scheme check
+  const [ok, firstShort] = await executor.canExecute();
+  console.log("canExecute (pre-registration):", ok, firstShort !== ethers.constants.AddressZero ? firstShort : "");
+
+  if (!process.env.SKIP_VERIFY && !isSimulation) await verifyExecutor(executorAddress, entries, release);
+
+  if (DEPLOY_ONLY) return console.log("\nDEPLOY_ONLY - executor ready:", executorAddress);
+
+  // ---------------------------------------------------------------- registration
+  // genericCall permission only - the executor can not register schemes, upgrade
+  // the controller, or move the avatar's funds.
+  const registerArgs = ethers.utils.defaultAbiCoder.encode(
+    ["address", "bytes32", "bytes4", "address"],
+    [executorAddress, ethers.constants.HashZero, GENERIC_CALL_PERMISSION, release.Avatar]
+  );
+
+  if (process.env.PRINT_ONLY) {
+    const ctrl = await ethers.getContractAt("Controller", release.Controller);
+    const safeTxData = ctrl.interface.encodeFunctionData("registerScheme", [
+      executorAddress,
+      ethers.constants.HashZero,
+      GENERIC_CALL_PERMISSION,
+      release.Avatar
+    ]);
+    console.log("\n=== Safe transaction - enter manually in the Safe UI ===");
+    console.log("safe      :", safeAddress);
+    console.log("to        :", release.Controller, "(Controller)");
+    console.log("value     : 0");
+    console.log("operation : 0 (CALL)");
+    console.log("data      :", safeTxData);
+    console.log("\ndecodes to: Controller.registerScheme(");
+    console.log("   _scheme     :", executorAddress, "(AdminBurnExecutor)");
+    console.log("   _paramsHash : 0x00..00");
+    console.log("   _permissions:", GENERIC_CALL_PERMISSION, "(genericCall only)");
+    console.log("   _avatar     :", release.Avatar, ")");
+    console.log("\nafter signing, run admin-burn-executor-execute.ts with EXECUTOR=" + executorAddress);
+    return;
+  }
+
+  console.log("\n=== proposing registerScheme ===");
+  if (isSimulation) {
+    const guardian = await ethers.getImpersonatedSigner(safeAddress);
+    await root.sendTransaction({ to: safeAddress, value: ethers.utils.parseEther("1") });
+    await executeViaGuardian(
+      [release.Controller],
+      [0],
+      ["registerScheme(address,bytes32,bytes4,address)"],
+      [registerArgs],
+      guardian,
+      networkName
+    );
+  } else {
+    const safeNetwork = SAFE_NETWORK[networkName];
+    if (!safeNetwork) throw new Error(`no Safe network mapping for '${networkName}'`);
+    await executeViaSafe(
+      [release.Controller],
+      [0],
+      ["registerScheme(address,bytes32,bytes4,address)"],
+      [registerArgs],
+      safeAddress,
+      safeNetwork,
+      {},
+      true // strict: throw instead of proposing a call that simulates false
+    );
+  }
+
+  console.log("\nproposed. 5 of 9 guardians must now sign in the Safe UI.");
+  console.log("executor:", executorAddress);
+  console.log(
+    "then run: EXECUTOR=" +
+      executorAddress +
+      " yarn hardhat run scripts/upgrades/admin-burn-executor-execute.ts --network " +
+      network.name
+  );
+  return executorAddress;
+};
+
+/**
+ * The constructor takes a dynamic struct array, which the shared verifyContract
+ * helper can not express on the command line - hardhat needs a --constructor-args
+ * module instead.
+ */
+const verifyExecutor = async (address: string, entries: any[], release: any) => {
+  const argsFile = path.join(__dirname, ".admin-burn-ctor-args.js");
+  const args = [
+    release.Controller,
+    release.GoodDollar,
+    (await ethers.getSigners())[0].address,
+    entries.map(e => [e.account, e.gdAmount.toString(), e.refundUSD.toString()])
+  ];
+  fs.writeFileSync(argsFile, `module.exports = ${JSON.stringify(args, null, 2)};\n`);
+  const cmd = `yarn hardhat verify --contract contracts/utils/AdminBurnExecutor.sol:AdminBurnExecutor --constructor-args ${argsFile} ${address} --network ${network.name}`;
+  console.log("\n=== verifying ===\n" + cmd);
+  try {
+    execSync(cmd, { stdio: "inherit" });
+  } catch (e) {
+    console.warn("verification failed (non-fatal). re-run manually:\n" + cmd);
+  }
+};
+
+export const main = async () => {
+  await deploy();
+};
+if (process.argv[1].includes("admin-burn-executor-deploy"))
+  main().catch(e => {
+    console.error(e);
+    process.exit(1);
+  });

--- a/scripts/upgrades/admin-burn-executor-execute.ts
+++ b/scripts/upgrades/admin-burn-executor-execute.ts
@@ -1,0 +1,167 @@
+/***
+ * Run a registered AdminBurnExecutor: burn the whole list in one transaction and
+ * print the refund ledger the burns produced.
+ *
+ * Prerequisites:
+ *  - the SuperGoodDollar implementation with `adminBurn` is live
+ *  - guardians have signed `registerScheme(executor, 0x0, 0x00000010, avatar)`
+ *  - the signer is the executor's `owner` (the deployer, unless it was changed)
+ *
+ * Modes (env):
+ *   EXECUTOR=0x..   required - the deployed AdminBurnExecutor
+ *   DRY=true        preflight + callStatic only, sends no transaction
+ *   CANCEL=1        call cancel() instead: drop the permission, burn nothing
+ *   OUT=path.json   write the refund ledger to this file (default alongside the script)
+ */
+import fs from "fs";
+import path from "path";
+import { network, ethers } from "hardhat";
+import dao from "../../releases/deployment.json";
+
+let { name: networkName } = network;
+networkName = networkName.replace("-fork", "");
+
+const DRY = process.env.DRY === "true" || process.env.DRY === "1";
+const CANCEL = process.env.CANCEL === "true" || process.env.CANCEL === "1";
+
+export const execute = async () => {
+  const [root] = await ethers.getSigners();
+  const release: { [key: string]: any } = dao[networkName];
+
+  const executorAddress = process.env.EXECUTOR;
+  if (!executorAddress) throw new Error("EXECUTOR=0x... is required");
+  if ((await ethers.provider.getCode(executorAddress)).length <= 2)
+    throw new Error(`no code at EXECUTOR ${executorAddress}`);
+
+  const executor = await ethers.getContractAt("AdminBurnExecutor", executorAddress);
+  const supergd = await ethers.getContractAt("SuperGoodDollar", release.GoodDollar);
+  const ctrl = await ethers.getContractAt("Controller", release.Controller);
+
+  const [owner, executed, entries, totalGD, totalUSD] = await Promise.all([
+    executor.owner(),
+    executor.executed(),
+    executor.getEntries(),
+    executor.totalGDToBurn(),
+    executor.totalRefundUSD()
+  ]);
+  const registered = await ctrl.isSchemeRegistered(executorAddress, release.Avatar);
+  const perms = await ctrl.getSchemePermissions(executorAddress, release.Avatar);
+
+  console.log("=== executor ===");
+  console.log({
+    networkName,
+    executor: executorAddress,
+    owner,
+    signer: root.address,
+    executed,
+    registered,
+    permissions: perms,
+    entries: entries.length,
+    totalGDToBurn: ethers.utils.formatEther(totalGD),
+    totalRefundUSD: ethers.utils.formatEther(totalUSD)
+  });
+
+  if (executed) throw new Error("executor has already run - deploy a new one for a new list");
+  if (owner.toLowerCase() !== root.address.toLowerCase())
+    throw new Error(`signer ${root.address} is not the executor owner ${owner}`);
+
+  if (CANCEL) {
+    if (DRY) return console.log("\nDRY - would call cancel() and drop the permission.");
+    console.log("\n=== cancel ===");
+    const tx = await (await executor.cancel()).wait();
+    console.log("cancelled in", tx.transactionHash);
+    console.log("still registered:", await ctrl.isSchemeRegistered(executorAddress, release.Avatar));
+    return;
+  }
+
+  if (!registered)
+    throw new Error(`executor is not a registered scheme on the Controller - guardians must sign registerScheme first`);
+
+  // ---------------------------------------------------------------- preflight
+  console.log("\n=== preflight ===");
+  const [ok, firstShort] = await executor.canExecute();
+  const balancesBefore: { [k: string]: any } = {};
+  const rows: any[] = [];
+  for (const e of entries) {
+    const balance = await supergd.balanceOf(e.account);
+    balancesBefore[e.account] = balance;
+    rows.push({
+      account: e.account,
+      burnGD: ethers.utils.formatEther(e.gdAmount),
+      balanceGD: ethers.utils.formatEther(balance),
+      enough: balance.gte(e.gdAmount),
+      refundUSD: ethers.utils.formatEther(e.refundUSD)
+    });
+  }
+  console.table(rows);
+  console.log("canExecute:", ok, firstShort !== ethers.constants.AddressZero ? `short: ${firstShort}` : "");
+  if (!ok)
+    throw new Error(
+      firstShort !== ethers.constants.AddressZero
+        ? `${firstShort} holds less than its listed burn amount - execute() is all-or-nothing`
+        : "canExecute() is false - check scheme registration and token ownership"
+    );
+
+  const supplyBefore = await supergd.totalSupply();
+  await executor.callStatic.execute();
+  console.log("execute() simulation: OK");
+
+  if (DRY) return console.log("\nDRY run complete - nothing burned.");
+
+  // ---------------------------------------------------------------- execute
+  console.log("\n=== executing ===");
+  const receipt = await (await executor.execute()).wait();
+  console.log("burned in", receipt.transactionHash, "gas", receipt.gasUsed.toString());
+
+  // ---------------------------------------------------------------- ledger
+  const burns = receipt.events
+    .filter(e => e.address.toLowerCase() === executorAddress.toLowerCase() && e.event === "AdminBurn")
+    .map(e => ({
+      account: e.args.account,
+      burnedGD: ethers.utils.formatEther(e.args.gdAmount),
+      refundUSD: ethers.utils.formatEther(e.args.refundUSD),
+      balanceBefore: ethers.utils.formatEther(balancesBefore[e.args.account] ?? 0)
+    }));
+
+  const after: any[] = [];
+  for (const b of burns)
+    after.push({ ...b, balanceAfter: ethers.utils.formatEther(await supergd.balanceOf(b.account)) });
+  console.table(after);
+
+  const supplyAfter = await supergd.totalSupply();
+  const summary = {
+    network: networkName,
+    executor: executorAddress,
+    txHash: receipt.transactionHash,
+    block: receipt.blockNumber,
+    accounts: burns.length,
+    totalBurnedGD: ethers.utils.formatEther(totalGD),
+    totalRefundUSD: ethers.utils.formatEther(totalUSD),
+    supplyBefore: ethers.utils.formatEther(supplyBefore),
+    supplyAfter: ethers.utils.formatEther(supplyAfter),
+    supplyDelta: ethers.utils.formatEther(supplyAfter.sub(supplyBefore)),
+    stillRegistered: await ctrl.isSchemeRegistered(executorAddress, release.Avatar),
+    refunds: after
+  };
+  console.log("\n=== summary ===");
+  console.log({ ...summary, refunds: `${after.length} entries` });
+
+  if (!supplyBefore.sub(supplyAfter).eq(totalGD))
+    console.warn("WARNING: total supply moved by a different amount than burned - other activity in the same block?");
+  if (summary.stillRegistered) console.warn("WARNING: executor is still a registered scheme - unregisterSelf failed?");
+
+  // the refund ledger is the input to the off-chain USD compensation process
+  const out = path.resolve(process.env.OUT || path.join(__dirname, `admin-burn-refunds-${networkName}.json`));
+  fs.writeFileSync(out, JSON.stringify(summary, null, 2));
+  console.log("refund ledger written to", out);
+  return summary;
+};
+
+export const main = async () => {
+  await execute();
+};
+if (process.argv[1].includes("admin-burn-executor-execute"))
+  main().catch(e => {
+    console.error(e);
+    process.exit(1);
+  });

--- a/scripts/upgrades/admin-burn-list.example.json
+++ b/scripts/upgrades/admin-burn-list.example.json
@@ -1,0 +1,14 @@
+[
+  {
+    "account": "0x0000000000000000000000000000000000000001",
+    "gd": "1000000.00",
+    "refundUSD": "1234.56",
+    "note": "exploiter EOA - drained via <incident>"
+  },
+  {
+    "account": "0x0000000000000000000000000000000000000002",
+    "gdWei": "500000000000000000000",
+    "refundUSDWei": "10000000000000000000",
+    "note": "raw base units are accepted too"
+  }
+]

--- a/test/token/SuperGoodDollar.test.ts
+++ b/test/token/SuperGoodDollar.test.ts
@@ -178,6 +178,51 @@ describe("SuperGoodDollar", async function () {
     await sgd.transfer(bob.address, tenDollars);
   });
 
+  it("adminBurn destroys illegitimate funds and reduces total supply", async function () {
+    await loadFixture(initialState);
+    await sgd.mint(eve.address, tenDollars);
+    const supplyBefore = await sgd.totalSupply();
+
+    await expect(sgd.connect(founder).adminBurn(eve.address, tenDollars))
+      .emit(sgd, "Burned")
+      .withArgs(founder.address, eve.address, tenDollars, "0x", "0x");
+
+    expect(await sgd.balanceOf(eve.address)).equal(0);
+    expect(await sgd.totalSupply()).equal(supplyBefore.sub(tenDollars));
+  });
+
+  it("adminBurn is only callable by the owner", async function () {
+    await loadFixture(initialState);
+    await sgd.mint(eve.address, tenDollars);
+
+    await expect(
+      sgd.connect(eve).adminBurn(eve.address, tenDollars)
+    ).revertedWith("not owner");
+    await expect(
+      sgd.connect(alice).adminBurn(eve.address, tenDollars)
+    ).revertedWith("not owner");
+  });
+
+  it("adminBurn works while paused", async function () {
+    await loadFixture(initialState);
+    await sgd.mint(eve.address, tenDollars);
+    await sgd.connect(founder).pause();
+
+    await sgd.connect(founder).adminBurn(eve.address, tenDollars);
+    expect(await sgd.balanceOf(eve.address)).equal(0);
+
+    await sgd.connect(founder).unpause();
+  });
+
+  it("adminBurn reverts when exceeding the available balance", async function () {
+    await loadFixture(initialState);
+    await sgd.mint(eve.address, tenDollars);
+
+    await expect(
+      sgd.connect(founder).adminBurn(eve.address, tenDollars.mul(2))
+    ).reverted;
+  });
+
   it("non-zero fees are applied", async function () {
     await loadFixture(initialState);
 


### PR DESCRIPTION
# Description

Adds the on-chain executor and the operational scripts for running an `adminBurn`
sweep against a list of addresses holding illegitimate G$, plus the USD refund
ledger the sweep produces.

About # (link your issue here)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

# Checklist:
- [ ] PR title matches follow: (Feature|Bug|Chore) Task Name
- [ ] My code follows the style guidelines of this project
- [ ] I have followed all the instructions described in the initial task (check Definitions of Done)
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added reference to a related issue in the repository
- [ ] I have added a detailed description of the changes proposed in the pull request. I am as descriptive as possible, assisting reviewers as much as possible.
- [ ] I have added screenshots related to my pull request (for frontend tasks)
- [ ] I have pasted a gif showing the feature.
- [ ] @mentions of the person or team responsible for reviewing proposed changes

## Summary by Sourcery

Enable auditable one-shot administrative sweeps that burn illegitimate G$ and produce an off-chain USD refund ledger.

New Features:
- Add owner-controlled `adminBurn` support to destroy illegitimate G$ balances, including while paused and without holder cooperation.
- Add a one-shot, immutable executor that burns an audited address list through Controller permissions and records per-account USD refund obligations.
- Add deployment, registration, execution, cancellation, preflight, verification, and refund-ledger scripts for operating administrative burn sweeps.

Enhancements:
- Remove the token’s generic recovery function while adding auditable safeguards around administrative burns, including balance and total-burn verification and automatic scheme deregistration.

Tests:
- Add coverage for successful administrative burns, owner authorization, paused-token operation, and insufficient-balance failures.